### PR TITLE
GPGGA: fix satellites in-use, not in-view.

### DIFF
--- a/include/nmealib/gpgga.h
+++ b/include/nmealib/gpgga.h
@@ -53,7 +53,7 @@ extern "C" {
  * | longitude   | Longitude, in NDEG (DDDMM.SSS)                         | LON (2)        |
  * | ew          | East or West ('E' or 'W')                              | LON (2)        |
  * | signal      | Signal quality (see the NMEALIB_SIG_* defines)         | SIG            |
- * | satellites  | Number of satellites being tracked                     | SATINVIEWCOUNT |
+ * | satellites  | Number of satellites in use                            | SATINUSECOUNT  |
  * | hdop        | Horizontal dilution of position                        | HDOP           |
  * | elv         | Elevation above mean sea level, in meters              | ELV (3)        |
  * | elv unit    | Unit of elevation ('M')                                | ELV (3)        |
@@ -88,7 +88,7 @@ typedef struct _NmeaGPGGA {
   double       longitude;
   char         longitudeEW;
   NmeaSignal   sig;
-  unsigned int inViewCount;
+  unsigned int inUseCount;
   double       hdop;
   double       elevation;
   char         elevationM;

--- a/src/gpgga.c
+++ b/src/gpgga.c
@@ -45,7 +45,7 @@ bool nmeaGPGGAParse(const char *s, const size_t sz, NmeaGPGGA *pack) {
   pack->latitude = NaN;
   pack->longitude = NaN;
   pack->sig = INT_MAX;
-  pack->inViewCount = UINT_MAX;
+  pack->inUseCount = UINT_MAX;
   pack->hdop = NaN;
   pack->elevation = NaN;
   pack->height = NaN;
@@ -61,7 +61,7 @@ bool nmeaGPGGAParse(const char *s, const size_t sz, NmeaGPGGA *pack) {
       &pack->longitude, //
       &pack->longitudeEW, //
       &pack->sig, //
-      &pack->inViewCount, //
+      &pack->inUseCount, //
       &pack->hdop, //
       &pack->elevation, //
       &pack->elevationM, //
@@ -122,10 +122,10 @@ bool nmeaGPGGAParse(const char *s, const size_t sz, NmeaGPGGA *pack) {
     pack->sig = NMEALIB_SIG_INVALID;
   }
 
-  if (pack->inViewCount != UINT_MAX) {
-    nmeaInfoSetPresent(&pack->present, NMEALIB_PRESENT_SATINVIEWCOUNT);
+  if (pack->inUseCount != UINT_MAX) {
+    nmeaInfoSetPresent(&pack->present, NMEALIB_PRESENT_SATINUSECOUNT);
   } else {
-    pack->inViewCount = 0;
+    pack->inUseCount = 0;
   }
 
   if (!isNaN(pack->hdop)) {
@@ -215,9 +215,9 @@ void nmeaGPGGAToInfo(const NmeaGPGGA *pack, NmeaInfo *info) {
     nmeaInfoSetPresent(&info->present, NMEALIB_PRESENT_SIG);
   }
 
-  if (nmeaInfoIsPresentAll(pack->present, NMEALIB_PRESENT_SATINVIEWCOUNT)) {
-    info->satellites.inViewCount = pack->inViewCount;
-    nmeaInfoSetPresent(&info->present, NMEALIB_PRESENT_SATINVIEWCOUNT);
+  if (nmeaInfoIsPresentAll(pack->present, NMEALIB_PRESENT_SATINUSECOUNT)) {
+    info->satellites.inUseCount = pack->inUseCount;
+    nmeaInfoSetPresent(&info->present, NMEALIB_PRESENT_SATINUSECOUNT);
   }
 
   if (nmeaInfoIsPresentAll(pack->present, NMEALIB_PRESENT_HDOP)) {
@@ -285,9 +285,9 @@ void nmeaGPGGAFromInfo(const NmeaInfo *info, NmeaGPGGA *pack) {
     pack->sig = NMEALIB_SIG_INVALID;
   }
 
-  if (nmeaInfoIsPresentAll(info->present, NMEALIB_PRESENT_SATINVIEWCOUNT)) {
-    pack->inViewCount = info->satellites.inViewCount;
-    nmeaInfoSetPresent(&pack->present, NMEALIB_PRESENT_SATINVIEWCOUNT);
+  if (nmeaInfoIsPresentAll(info->present, NMEALIB_PRESENT_SATINUSECOUNT)) {
+    pack->inUseCount = info->satellites.inUseCount;
+    nmeaInfoSetPresent(&pack->present, NMEALIB_PRESENT_SATINUSECOUNT);
   }
 
   if (nmeaInfoIsPresentAll(info->present, NMEALIB_PRESENT_HDOP)) {
@@ -371,8 +371,8 @@ size_t nmeaGPGGAGenerate(char *s, const size_t sz, const NmeaGPGGA *pack) {
     chars += snprintf(dst, available, ",");
   }
 
-  if (nmeaInfoIsPresentAll(pack->present, NMEALIB_PRESENT_SATINVIEWCOUNT)) {
-    chars += snprintf(dst, available, ",%02u", pack->inViewCount);
+  if (nmeaInfoIsPresentAll(pack->present, NMEALIB_PRESENT_SATINUSECOUNT)) {
+    chars += snprintf(dst, available, ",%02u", pack->inUseCount);
   } else {
     chars += snprintf(dst, available, ",");
   }


### PR DESCRIPTION
The GPGGA sentence includes the satellite **in-use** count, not the **in-view** count. 

- http://aprs.gids.nl/nmea/#gga
- https://docs.novatel.com/OEM7/Content/Logs/GPGGA.htm

Note: Some online descriptions of the sentence parameters are wrong, or not clear.
